### PR TITLE
Switch line endings from CR to LF

### DIFF
--- a/Robot_Lights/Robot_Lights.ino
+++ b/Robot_Lights/Robot_Lights.ino
@@ -1,1 +1,24 @@
-#include <FastLED.h> //#define DATA_PIN 6 not using this because each strip has it's own defined in fastled.addleds#define NUM_LEDS 64 CRGB leds[NUM_LEDS];void setup() {  FastLED.addLeds<NEOPIXEL,1>(leds, NUM_LEDS);  FastLED.addLeds<NEOPIXEL,1>(leds, NUM_LEDS);  }void loop() {  auton();  }void auton() {  leds[0, 64] = CRGB::Blue;  FastLED.show();  delay(500);  // Now turn the LED off, then pause  leds[0] = CRGB::Black;  FastLED.show();  delay(500);}
+#include <FastLED.h>
+ 
+//#define DATA_PIN 6 not using this because each strip has it's own defined in fastled.addleds
+#define NUM_LEDS 64
+ 
+CRGB leds[NUM_LEDS];
+void setup() {
+  FastLED.addLeds<NEOPIXEL,1>(leds, NUM_LEDS);
+  FastLED.addLeds<NEOPIXEL,1>(leds, NUM_LEDS);  
+}
+
+void loop() {
+  auton();  
+}
+
+void auton() {
+  leds[0, 64] = CRGB::Blue;
+  FastLED.show();
+  delay(500);
+  // Now turn the LED off, then pause
+  leds[0] = CRGB::Black;
+  FastLED.show();
+  delay(500);
+}


### PR DESCRIPTION
I'm not entirely certain how you ended up with CR line endings in the first place, but Git likes LFs a lot better. Don't believe me? Check out [what your RobotLights.ino looks like on GitHub](https://github.com/FRC5892/2019LEDS/blob/0565e5da91ccba58db6f5ec45144f173eedb0d17/Robot_Lights/Robot_Lights.ino).

Obviously you're free to reject my PR, but this change would make things a lot nicer for people looking at our code, since they wouldn't have to clone it to get actual line breaks instead of `^M`.